### PR TITLE
sepolicy: remove redundant sepolicy

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -166,10 +166,8 @@ BOARD_SEPOLICY_DIRS += \
 BOARD_SEPOLICY_UNION += \
     bluetooth_loader.te \
     file_contexts \
-    healthd.te \
     mediaserver.te \
     property_contexts \
-    qseecomd.te \
     system_app.te \
     time_daemon.te \
     vold.te \

--- a/sepolicy/healthd.te
+++ b/sepolicy/healthd.te
@@ -1,1 +1,0 @@
-allow healthd rtc_device:chr_file rw_file_perms;

--- a/sepolicy/qseecomd.te
+++ b/sepolicy/qseecomd.te
@@ -1,1 +1,0 @@
-allow tee system_prop:property_service set;


### PR DESCRIPTION
it has been defined in the qcom/sepolicy
https://github.com/CyanogenMod/android_device_qcom_sepolicy/blob/cm-12.1/common/healthd.te#L7
https://github.com/CyanogenMod/android_device_qcom_sepolicy/blob/cm-12.1/common/qseecomd.te#L56